### PR TITLE
Overall improvements

### DIFF
--- a/Example/StateKit.xcodeproj/project.pbxproj
+++ b/Example/StateKit.xcodeproj/project.pbxproj
@@ -8,13 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		24D63F2C1C9343A1002894E3 /* StateKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 24D63F2B1C9343A1002894E3 /* StateKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		24D63F381C9343BD002894E3 /* NSMutableArray+Queue.h in Headers */ = {isa = PBXBuildFile; fileRef = 24D63F311C9343BD002894E3 /* NSMutableArray+Queue.h */; };
+		24D63F381C9343BD002894E3 /* NSMutableArray+Queue.h in Headers */ = {isa = PBXBuildFile; fileRef = 24D63F311C9343BD002894E3 /* NSMutableArray+Queue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		24D63F391C9343BD002894E3 /* NSMutableArray+Queue.m in Sources */ = {isa = PBXBuildFile; fileRef = 24D63F321C9343BD002894E3 /* NSMutableArray+Queue.m */; };
-		24D63F3A1C9343BD002894E3 /* SKState.h in Headers */ = {isa = PBXBuildFile; fileRef = 24D63F331C9343BD002894E3 /* SKState.h */; };
+		24D63F3A1C9343BD002894E3 /* SKState.h in Headers */ = {isa = PBXBuildFile; fileRef = 24D63F331C9343BD002894E3 /* SKState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		24D63F3B1C9343BD002894E3 /* SKState.m in Sources */ = {isa = PBXBuildFile; fileRef = 24D63F341C9343BD002894E3 /* SKState.m */; };
-		24D63F3C1C9343BD002894E3 /* SKStateChart.h in Headers */ = {isa = PBXBuildFile; fileRef = 24D63F351C9343BD002894E3 /* SKStateChart.h */; };
+		24D63F3C1C9343BD002894E3 /* SKStateChart.h in Headers */ = {isa = PBXBuildFile; fileRef = 24D63F351C9343BD002894E3 /* SKStateChart.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		24D63F3D1C9343BD002894E3 /* SKStateChart.m in Sources */ = {isa = PBXBuildFile; fileRef = 24D63F361C9343BD002894E3 /* SKStateChart.m */; };
-		24D63F3E1C9343BD002894E3 /* SKTypeDefs.h in Headers */ = {isa = PBXBuildFile; fileRef = 24D63F371C9343BD002894E3 /* SKTypeDefs.h */; };
+		24D63F3E1C9343BD002894E3 /* SKTypeDefs.h in Headers */ = {isa = PBXBuildFile; fileRef = 24D63F371C9343BD002894E3 /* SKTypeDefs.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };

--- a/Pod/Classes/ObjC/SKStateChart.m
+++ b/Pod/Classes/ObjC/SKStateChart.m
@@ -24,7 +24,11 @@
 
 static NSString *kDefaultRootStateName = @"root";
 static NSString *kSubStringKey = @"subStates";
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
 static NSUInteger kMaxStackCount = 100;
+#pragma clang diagnostic pop
 
 NSString *const SKStateChartDidChangeStateNotification = @"SKStateChartDidChangeStateNotification";
 

--- a/Pod/Classes/Swift/SKSwiftHelpers.swift
+++ b/Pod/Classes/Swift/SKSwiftHelpers.swift
@@ -7,9 +7,9 @@
 import Foundation
 
 /// An alias for converting a closure to StateKit's expected block
-typealias SKStateBlock = @convention(block) (sc: SKStateChart) -> Void
+typealias SKStateBlock = @convention(block) (_ sc: SKStateChart) -> Void
 
 /// A convenience function for converting an SKStateBlock to AnyObject so that it may be inserted into a Swift dictionary
-func SKStateBlockify(block:(sc: SKStateChart) -> Void) -> AnyObject {
-	return unsafeBitCast(block as SKStateBlock, AnyObject.self)
+func SKStateBlockify(block:@escaping (_ sc: SKStateChart) -> Void) -> AnyObject {
+	return unsafeBitCast(block as SKStateBlock, to: AnyObject.self)
 }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # StateKit
 
+[![Build Status](http://img.shields.io/travis/sghiassy/StateKit/master.svg?style=flat)](https://travis-ci.org/sghiassy/StateKit)
+[![Pod Version](http://img.shields.io/cocoapods/v/StateKit.svg?style=flat)](http://cocoadocs.org/docsets/StateKit/)
+[![Pod Platform](http://img.shields.io/cocoapods/p/StateKit.svg?style=flat)](http://cocoadocs.org/docsets/StateKit/)
+[![Pod License](http://img.shields.io/cocoapods/l/StateKit.svg?style=flat)](https://github.com/sghiassy/StateKit/blob/master/LICENSE)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 <img title="StateKit Logo" src="http://cloud.shaheenghiassy.com/image/252G1229101R/StateKit-Logo.png" width="800" />
 
-[StateKit](https://github.com/sghiassy/StateKit) is a framework for iOS and OSX, to capture, document and manage state, in order to keep your application code calm & sane.
+[StateKit](https://github.com/sghiassy/StateKit) is a framework for iOS, OSX, tvOS or watchOS, to capture, document and manage state, in order to keep your application code calm & sane.
 
 ## Quick Example
 

--- a/StateKit.podspec
+++ b/StateKit.podspec
@@ -9,8 +9,8 @@
 
 Pod::Spec.new do |s|
   s.name             = "StateKit"
-  s.version          = "0.1.1"
-  s.summary          = "StateKit is a StateChart written for iOS/MacOSX Development"
+  s.version          = "0.2.0"
+  s.summary          = "StateKit is a StateChart written for iOS/MacOSX/tvOS/watchOS Development"
   s.description      = <<-DESC
                        StateKit is a framework to model, capture, manipulate and interact with State.
 
@@ -18,18 +18,16 @@ Pod::Spec.new do |s|
                        This is different from a Finite State Machine (FSM) that models state as a graph
                        DESC
   s.homepage         = "https://github.com/sghiassy/StateKit"
-  # s.screenshots     = "www.example.com/screenshots_1", "www.example.com/screenshots_2"
   s.license          = 'MIT'
   s.author           = { "Shaheen Ghiassy" => "shaheen@groupon.com" }
   s.source           = { :git => "https://github.com/sghiassy/StateKit.git", :tag => s.version.to_s }
-  # s.social_media_url = 'https://twitter.com/shaheenghiassy'
 
-  s.platform     = :ios, '7.0'
+  s.ios.deployment_target = '7.0'
+  s.osx.deployment_target = '10.8'
+  s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '2.0'
+
   s.requires_arc = true
-
-  s.resource_bundles = {
-    'StateKit' => ['Pod/Assets/*.png']
-  }
 
   s.default_subspec = 'ObjC'
 
@@ -39,9 +37,11 @@ Pod::Spec.new do |s|
 
   s.subspec 'Swift' do |swift|
     swift.source_files = 'Pod/Classes/Swift'
+    swift.ios.deployment_target = '8.0'
+    swift.osx.deployment_target = '10.10'
+    swift.tvos.deployment_target = '9.0'
+    swift.watchos.deployment_target = '2.0'
+    swift.dependency 'StateKit/ObjC'
   end
 
-  # s.public_header_files = 'Pod/Classes/**/*.h'
-  # s.frameworks = 'UIKit', 'MapKit'
-  # s.dependency 'AFNetworking', '~> 2.3'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "state-kit",
-  "version": "0.0.5",
+  "version": "0.2.0",
   "description": "[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Support for **OSX, watchOS, tvOS** platforms via CocoaPods
- Cleaned up the podspec (no longer allowed to define an empty resource_bundle). 
- Bumped the version to **0.2.0**
- Updated a bit the readme with the new platforms and some badges
- Swift 3 support + headers made public inside target to avoid compilation error (include of non-modular header inside framework)
- Fixed a warning in release builds due to `NSAssert`

Those are the new badges added to the readme:
[![Build Status](http://img.shields.io/travis/sghiassy/StateKit/master.svg?style=flat)](https://travis-ci.org/sghiassy/StateKit)
[![Pod Version](http://img.shields.io/cocoapods/v/StateKit.svg?style=flat)](http://cocoadocs.org/docsets/StateKit/)
[![Pod Platform](http://img.shields.io/cocoapods/p/StateKit.svg?style=flat)](http://cocoadocs.org/docsets/StateKit/)
[![Pod License](http://img.shields.io/cocoapods/l/StateKit.svg?style=flat)](https://github.com/sghiassy/StateKit/blob/master/LICENSE)
[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)

Soon enough we will see this
[![Pod Platform](http://img.shields.io/cocoapods/p/SDWebImage.svg?style=flat)]()