### PR TITLE
Don't fire SKStateChartDidChangeStateNotification for intermediary state changes

### DIFF
--- a/Pod/Classes/ObjC/SKStateChart.h
+++ b/Pod/Classes/ObjC/SKStateChart.h
@@ -23,6 +23,6 @@
 @end
 
 /**
- A Notification posted when `currentState` changes to a new value.
+ A Notification posted when `currentState` changes to a new value - does not trigger for intermediate states
  */
 extern NSString *const SKStateChartDidChangeStateNotification;

--- a/Pod/Classes/ObjC/SKStateChart.m
+++ b/Pod/Classes/ObjC/SKStateChart.m
@@ -129,6 +129,8 @@ NSString *const SKStateChartDidChangeStateNotification = @"SKStateChartDidChange
     }
 
     self.stackCount = 0;
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:SKStateChartDidChangeStateNotification object:self];
 }
 
 - (NSArray *)pathToRootFromState:(SKState *)startState {
@@ -183,7 +185,6 @@ NSString *const SKStateChartDidChangeStateNotification = @"SKStateChartDidChange
     }
 
     [self didChangeValueForKey:NSStringFromSelector(@selector(currentState))];
-    [[NSNotificationCenter defaultCenter] postNotificationName:SKStateChartDidChangeStateNotification object:self];
 }
 
 - (void)popCurrentStateToParentState {
@@ -197,7 +198,6 @@ NSString *const SKStateChartDidChangeStateNotification = @"SKStateChartDidChange
     }
 
     [self didChangeValueForKey:NSStringFromSelector(@selector(currentState))];
-    [[NSNotificationCenter defaultCenter] postNotificationName:SKStateChartDidChangeStateNotification object:self];
 }
 
 @end


### PR DESCRIPTION
`SKStateChartDidChangeStateNotification` should only fire when switching from state A to state B, not for every intermediate state