### PR TITLE
Added messageBubblingEnabled and debugLoggingEnabled options to SKStateChart

### DIFF
--- a/Pod/Classes/ObjC/SKStateChart.h
+++ b/Pod/Classes/ObjC/SKStateChart.h
@@ -25,6 +25,13 @@
  */
 @property (nonatomic, assign) BOOL messageBubblingEnabled;
 
+/**
+ default set to NO
+ 
+ Log messaging and state changing using `NSLog`
+ */
+@property (nonatomic, assign) BOOL debugLoggingEnabled;
+
 - (instancetype)initWithStateChart:(NSDictionary *)stateChart;
 
 - (void)goToState:(NSString *)goToState;

--- a/Pod/Classes/ObjC/SKStateChart.h
+++ b/Pod/Classes/ObjC/SKStateChart.h
@@ -14,6 +14,17 @@
 
 @property (nonatomic, strong, readonly) SKState *currentState;
 
+/**
+ default set to YES
+ 
+ https://github.com/sghiassy/StateKit#message-bubbling
+ 
+ Messages are first sent to the current state to see if there is a receiver for the message. If the current state does not respond to the message, the state chart will begin to bubble up the tree to find any parent states that respond to the message. If the current state plus any of the current state's parent states, do not respond to the message, the message will be quietly ignored.
+ 
+ Set this to NO if you want a finite-state machine behavior.
+ */
+@property (nonatomic, assign) BOOL messageBubblingEnabled;
+
 - (instancetype)initWithStateChart:(NSDictionary *)stateChart;
 
 - (void)goToState:(NSString *)goToState;

--- a/Pod/Classes/ObjC/SKStateChart.m
+++ b/Pod/Classes/ObjC/SKStateChart.m
@@ -43,6 +43,7 @@ NSString *const SKStateChartDidChangeStateNotification = @"SKStateChartDidChange
     if (self) {
         _stackCount = 0;
         _messageBubblingEnabled = YES;
+        _debugLoggingEnabled = NO;
         NSDictionary *rootTree = [stateChart objectForKey:kDefaultRootStateName];
         NSAssert(rootTree != nil, @"The stateChart you input does not have a root state");
         _rootState = [self initializeDictionaryAsATree:rootTree withStateName:kDefaultRootStateName andParentState:nil];
@@ -86,6 +87,10 @@ NSString *const SKStateChartDidChangeStateNotification = @"SKStateChartDidChange
     SKState *statePointer = self.currentState;
     MessageBlock messageBlock = [statePointer blockForMessage:message];
 
+    if (self.debugLoggingEnabled) {
+        NSLog(@"stateChart %@ received message %@", self, message);
+    }
+
     if (self.messageBubblingEnabled) {
         while (statePointer != nil && messageBlock == nil) {
             statePointer = statePointer.parentState;
@@ -108,6 +113,10 @@ NSString *const SKStateChartDidChangeStateNotification = @"SKStateChartDidChange
     // Before proceding make sure that we actual found a state of that name
     if (toState == nil) {
         return;
+    }
+
+    if (self.debugLoggingEnabled) {
+        NSLog(@"stateChart %@ transition from state %@ to state %@", self, self.currentState.name, goToState);
     }
 
     // Build path from node to parent for goToState

--- a/Pod/Classes/ObjC/SKStateChart.m
+++ b/Pod/Classes/ObjC/SKStateChart.m
@@ -42,6 +42,7 @@ NSString *const SKStateChartDidChangeStateNotification = @"SKStateChartDidChange
 
     if (self) {
         _stackCount = 0;
+        _messageBubblingEnabled = YES;
         NSDictionary *rootTree = [stateChart objectForKey:kDefaultRootStateName];
         NSAssert(rootTree != nil, @"The stateChart you input does not have a root state");
         _rootState = [self initializeDictionaryAsATree:rootTree withStateName:kDefaultRootStateName andParentState:nil];
@@ -85,9 +86,11 @@ NSString *const SKStateChartDidChangeStateNotification = @"SKStateChartDidChange
     SKState *statePointer = self.currentState;
     MessageBlock messageBlock = [statePointer blockForMessage:message];
 
-    while (statePointer != nil && messageBlock == nil) {
-        statePointer = statePointer.parentState;
-        messageBlock = [statePointer blockForMessage:message];
+    if (self.messageBubblingEnabled) {
+        while (statePointer != nil && messageBlock == nil) {
+            statePointer = statePointer.parentState;
+            messageBlock = [statePointer blockForMessage:message];
+        }
     }
 
     if (messageBlock) {


### PR DESCRIPTION
- Added `messageBubblingEnabled` option to `SKStateChart`. Default is enabled. Use this to disable message bubbling if needed (behaves like a classic state-machine).
- Added `debugLoggingEnabled ` option to `SKStateChart`. Default is disabled. Use this to log all the messages and state changes.